### PR TITLE
Add support for fulllengthaudiobooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ This Python script downloads all chapters of an audiobook from `tokybook.com` or
 ![Issues](https://img.shields.io/github/issues/aviiciii/tokybook?color=informational)
 
 ## Supported Sites
+
 * [tokybook.com](https://tokybook.com)
 * [zaudiobooks.com](https://zaudiobooks.com)
+* [fulllengthaudiobooks.net](https://fulllengthaudiobooks.net/)
 * [goldenaudiobook.com](https://goldenaudiobook.com) (only on Mac)
 
 ## Features
@@ -81,14 +83,13 @@ uv run main.py
 pip install -r requirements.txt
 ```
 
-
 ```bash
 python main.py # or python3 main.py on some systems
 ```
 
 The script will then prompt you to enter the following information:
 
-* The URL for the audiobook. (It must be from `tokybook.com` or `zaudiobooks.com` or `goldenaudiobook.com`.)
+* The URL for the audiobook. (It must be from `tokybook.com` , `zaudiobooks.com` , `fulllengthaudiobooks.net` or  `goldenaudiobook.com`.)
 * Optional details like the author, cover image URL, year, and narrator.
 
 After you provide the details, it will display a summary table, and the download will begin.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ python main.py # or python3 main.py on some systems
 
 The script will then prompt you to enter the following information:
 
-* The URL for the audiobook. (It must be from `tokybook.com` , `zaudiobooks.com` , `fulllengthaudiobooks.net` or  `goldenaudiobook.com`.)
+* The URL for the audiobook. (It must be from `tokybook.com`, `zaudiobooks.com`, `fulllengthaudiobooks.net` or `goldenaudiobook.com`.)
 * Optional details like the author, cover image URL, year, and narrator.
 
 After you provide the details, it will display a summary table, and the download will begin.

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ import time
 from scrapers.tokybook import TokybookScraper
 from scrapers.goldenaudiobook import GoldenAudiobookScraper
 from scrapers.zaudiobooks import ZaudiobooksScraper
+from scrapers.fulllengthaudiobooks import FulllengthAudiobooksScraper
 
 
 console = Console()
@@ -35,6 +36,8 @@ def get_scraper(url):
         return GoldenAudiobookScraper()
     if "zaudiobooks.com" in url:
         return ZaudiobooksScraper()
+    if "fulllengthaudiobooks.net" in url:
+        return FulllengthAudiobooksScraper()
     return None
 
 

--- a/scrapers/fulllengthaudiobooks.py
+++ b/scrapers/fulllengthaudiobooks.py
@@ -1,0 +1,109 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import Dict, Any, Optional
+import re
+
+class FulllengthAudiobooksScraper:
+    """
+    Scrape audiobook metadata and chapter MP3 links from a fulllengthaudiobooks.net page.
+    """
+    
+    def _clean_title_string(self, raw_title: str) -> Dict[str, Optional[str]]:
+        """
+        Cleans the raw title string (e.g., 'Author - Title Audiobook Free')
+        and attempts to separate the author and main title.
+        """
+        cleaned = raw_title.strip()
+        
+        # Remove common suffixes and redundant text
+        cleaned = re.sub(r'\s*(Audiobook\s*Free|Audio Book Online|Audiobook|Free)$', '', cleaned, flags=re.I).strip()
+        
+        # Try to split by common separators like '--' or '-'
+        parts = re.split(r'\s*[-\u2013]\s*', cleaned, maxsplit=1) # \u2013 is the en dash (&#8211;)
+
+        if len(parts) == 2:
+            author = parts[0].strip()
+            title = parts[1].strip()
+        else:
+            # Fallback if separation fails
+            author = None
+            title = cleaned
+
+        return {"title": title, "author": author}
+
+    def fetch_book_data(self, book_url: str) -> Dict[str, Any]:
+        """
+        Fetches the book page and extracts all relevant data including chapter URLs.
+        
+        Args:
+            book_url: The URL of the audiobook page to scrape.
+            
+        Returns:
+            A dictionary containing the extracted book metadata and chapters.
+        """
+        # Fetch the HTML content
+        print(f"Fetching data from: {book_url}")
+        try:
+            response = requests.get(book_url, timeout=10)
+            response.raise_for_status() # Raises an HTTPError for bad responses (4xx or 5xx)
+            html = response.text
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching URL: {e}")
+            return {}
+
+        soup = BeautifulSoup(html, "html.parser")
+
+        # 1. Extract Title and Author
+        raw_h1 = soup.find("h1", class_="entry-title post-title")
+        raw_title_text = raw_h1.text if raw_h1 else "Unknown Title"
+        
+        title_info = self._clean_title_string(raw_title_text)
+        
+        # 2. Extract Cover URL
+        # Target the main image inside the content area.
+        cover_tag = soup.select_one('.wp-caption img')
+        cover_url = cover_tag.get('src') if cover_tag else None
+
+        # 3. Extract Chapter Audio Links
+        chapters = []
+        # Find all <source> tags with type="audio/mpeg" inside the main content area
+        audio_sources = soup.select('.entry source[type="audio/mpeg"]')
+        
+        for index, source in enumerate(audio_sources):
+            chapter_url = source.get('src')
+            if chapter_url:
+                # Clean up the URL to remove query parameters like '?_=1'
+                clean_url = chapter_url.split('?')[0]
+                
+                chapter_title = f"Chapter {index + 1:03d}"
+                
+                chapters.append({
+                    "title": chapter_title,
+                    "url": clean_url
+                })
+
+        return {
+            "site": "fulllengthaudiobooks.net",
+            "book_url": book_url,
+            "title": title_info["title"],
+            "author": title_info["author"],
+            "narrator": None, # Narrator is not easily scrapable from this HTML
+            "year": None,    # Year is not easily scrapable from this HTML
+            "cover_url": cover_url,
+            "chapters": chapters,
+        }
+
+if __name__ == '__main__':
+    # This URL corresponds to the HTML provided by the user (Adam Silvera - They Both Die at the End)
+    TEST_URL = "https://fulllengthaudiobooks.net/adam-silvera-they-both-die-at-the-end-audiobook/"
+
+    scraper = FulllengthAudiobooksScraper()
+    book_data = scraper.fetch_book_data(TEST_URL)
+
+    if book_data:
+        import json
+        print("\n--- Extracted Book Data ---")
+        print(json.dumps(book_data, indent=4))
+        print(f"\nTotal Chapters Found: {len(book_data.get('chapters', []))}")
+        if book_data.get('chapters'):
+            print(f"Example Chapter 1 URL: {book_data['chapters'][0]['url']}")

--- a/test.py
+++ b/test.py
@@ -13,13 +13,17 @@ TEST_URLS = {
     #     "https://goldenaudiobook.net/andy-weir-project-hail-mary-audiobook/",
     #     "https://goldenaudiobook.net/pierce-brown-audiobook-red-rising/"
     # ],
-    "tokybook": [
-        "https://tokybook.com/post/project-hail-mary-746adb",
-        "https://tokybook.com/post/harry-potter-and-the-sorcerers-stone-book-1-5d0dc7"
-    ],
-    "zaudiobooks": [
-        "https://zaudiobooks.com/daisy-jones-the-six/",
-        "https://zaudiobooks.com/red-rising/"
+    # "tokybook": [
+    #     "https://tokybook.com/post/project-hail-mary-746adb",
+    #     "https://tokybook.com/post/harry-potter-and-the-sorcerers-stone-book-1-5d0dc7"
+    # ],
+    # "zaudiobooks": [
+    #     "https://zaudiobooks.com/daisy-jones-the-six/",
+    #     "https://zaudiobooks.com/red-rising/"
+    # ],
+    "fulllengthaudiobooks": [
+        "https://fulllengthaudiobooks.net/george-r-r-martin-world-of-ice-fire-audiobook/",
+        "https://fulllengthaudiobooks.net/john-green-looking-for-alaska-audiobook-2/"
     ]
 }
 


### PR DESCRIPTION
This pull request adds support for scraping audiobooks from `fulllengthaudiobooks.net` in addition to the previously supported sites. The update includes a new scraper class, updates to the main script to recognize the new site, and documentation/test changes to reflect the added functionality.

**Support for fulllengthaudiobooks.net:**

* Added a new scraper class `FulllengthAudiobooksScraper` in `scrapers/fulllengthaudiobooks.py` to extract audiobook metadata and chapter links from `fulllengthaudiobooks.net` pages.
* Updated `main.py` to import the new scraper and include logic in `get_scraper` to select it when a `fulllengthaudiobooks.net` URL is provided. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R25) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R39-R40)

**Documentation updates:**

* Added `fulllengthaudiobooks.net` to the list of supported sites and updated the usage instructions in `README.md` to mention the new site. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R17-R20) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R92)

**Test updates:**

* Updated `test.py` to include sample URLs for `fulllengthaudiobooks.net` and commented out the old site tests.